### PR TITLE
Change debug env variable to int

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DEBUG=False
+DEBUG=1
 MYSQL_DATABASE=borghive
 MYSQL_USER=borghive
 MYSQL_PASSWORD=borghive

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DEBUG=1
+DEBUG=0
 MYSQL_DATABASE=borghive
 MYSQL_USER=borghive
 MYSQL_PASSWORD=borghive


### PR DESCRIPTION
 as 'ionotify' in the 'watcher' container is throwing errors with booleans:


```
watcher_1  |   File "/usr/local/lib/python3.8/site-packages/inotify/adapters.py", line 37, in <module>
watcher_1  |     _IS_DEBUG = bool(int(os.environ.get('DEBUG', '0')))
watcher_1  | ValueError: invalid literal for int() with base 10: 'False'

```