### PR TITLE
add missing environment variables for LDAP used in init.sh

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,7 @@ LDAP_ORGANISATION=borghive
 LDAP_DOMAIN=borghive.local
 LDAP_ADMIN_PASSWORD=borghive
 LDAP_READONLY_USER=true
+BORG_LDAP_HOST=ldap://ldap
+BORG_LDAP_BASE_DN=dc=borghive,dc=local
+BORG_LDAP_READONLY_DN=cn=readonly,dc=borghive,dc=local
+BORG_LDAP_READONLY_USER_PASSWORD=readonly


### PR DESCRIPTION
nslcd failed to load in the 'borg' container as init.sh is using vars to cat into nslcd.conf. These vars are not part of .env (note that the dev docker file is not using an environment file but has all vars hardcoded)