### PR TITLE
fix(sshd-config): run authkeyscmd as nobody

### DIFF
--- a/borg/sshd_config
+++ b/borg/sshd_config
@@ -59,4 +59,4 @@ PermitTunnel no
 Match User *    # match all users
   # source stored environemnt to load the needed environment variables in the subshell AuthorizedKeysCommand creates.
   AuthorizedKeysCommand /bin/bash -c "set -a; . /etc/profile; /app/manage.py authorized_keys_check --user %u"
-  AuthorizedKeysCommandUser root
+  AuthorizedKeysCommandUser nobody


### PR DESCRIPTION
I don't know, why this is run as root. It is not needed IMHO.