### PR TITLE
fix(settings): loosen ssh pubkey regex

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -224,7 +224,7 @@ handler500 = 'borghive.views.error.error505'
 BORGHIVE = {
     'CONFIG_PATH': env('CONFIG_PATH', '/config'),
     'REPO_PATH': env('BORGHIVE_REPO_PATH', '/repos'),
-    'SSH_PUBLIC_KEY_REGEX': r'^((ssh|ecdsa)-[a-zA-Z0-9-]+) (AAAA[0-9A-Za-z+/=]+)( [\w\-@_\.]+)?$',
+    'SSH_PUBLIC_KEY_REGEX': r'^((ssh|ecdsa)-[a-zA-Z0-9-]+) (AAAA[0-9A-Za-z+/=]+)',
     'LDAP_USER_BASEDN': env('BORGHIVE_LDAP_USER_BASEDN', 'dc=borghive,dc=local')
 }
 


### PR DESCRIPTION
SSH pubkey do not seem to be required to contain an email address. Also [ansible generated ones](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#return-ssh_public_key) don't.
Let's loosen the regex a litte.