### PR TITLE
Switch OpenLDAP for OpenLDAP-Backup for backing up LDAP data

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,9 @@ LDAP_ORGANISATION=borghive
 LDAP_DOMAIN=borghive.local
 LDAP_ADMIN_PASSWORD=borghive
 LDAP_READONLY_USER=true
+# LDAP Backup settings. Config once a week, data daily
+LDAP_BACKUP_CONFIG_CRON_EXP="5 1 1 * *"
+LDAP_BACKUP_DATA_CRON_EXP="5 1 * * *"
 #
 # borg ldap settings
 BORG_LDAP_HOST=ldap://ldap

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:latest
     volumes:
       - mariadb-data:/var/lib/mysql
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -98,15 +98,18 @@ services:
       - "22:22"
 
   ldap:
-    image: osixia/openldap:latest
+    image: osixia/openldap-backup:latest
     environment:
       - LDAP_ORGANISATION=borghive
       - LDAP_DOMAIN=borghive.local
       - LDAP_ADMIN_PASSWORD=borghive
       - LDAP_READONLY_USER=true
+      - LDAP_BACKUP_CONFIG_CRON_EXP="*/5 * * * *"
+      - LDAP_BACKUP_DATA_CRON_EXP="*/5 * * * *"
     volumes:
       - ldap-data:/var/lib/ldap
       - ldap-config:/etc/ldap/slapd.d
+      - /var/backups/openldap:/data/backup
 
   redis:
     image: redis:latest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -109,7 +109,7 @@ services:
     volumes:
       - ldap-data:/var/lib/ldap
       - ldap-config:/etc/ldap/slapd.d
-      - /var/backups/openldap:/data/backup
+      - ldap-backup:/data/backup
 
   redis:
     image: redis:latest
@@ -118,6 +118,7 @@ volumes:
   mariadb-data:
   borg-repos:
   borg-config:
+  ldap-backup:
   ldap-data:
   ldap-config:
   static:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ volumes:
   mariadb-data:
   ldap-data:
   ldap-config:
+  ldap-backup:
   borg-config:
   static:
   borg-repos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     volumes:
       - ldap-data:/var/lib/ldap
       - ldap-config:/etc/ldap/slapd.d
-      - /var/backups/openldap:/data/backup
+      - ldap-backup:/data/backup
 
   redis:
     # image: redis:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,12 +69,13 @@ services:
 
   ldap:
     # image: osixia/openldap:latest
-    image: osixia/openldap:1.4.0-amd64
+    image: osixia/openldap-backup:1.4.0-amd64
     env_file:
       - .env
     volumes:
       - ldap-data:/var/lib/ldap
       - ldap-config:/etc/ldap/slapd.d
+      - /var/backups/openldap:/data/backup
 
   redis:
     # image: redis:latest


### PR DESCRIPTION
Resolving part of #65 , this swaps out openldap, for the openldap-backup container.

The openldap-backup container, is the same as openldap, but with added backup functionality.

It adds the volume mapping of `/var/backups/openldap` to the backup folder on the container, `/data/backup`. Backups of the config and the data are done as per the environment cron setting.

To do: Docs around this and how to disable it?